### PR TITLE
Implement auto compression choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ sequoiarecover backup --source /path/to/data --cloud backblaze --bucket my-bucke
 ```
 The `--mode` flag controls whether a **full** or **incremental** backup is performed.
 Incremental mode only archives files that have changed since the previous backup.
+You can control compression with `--compression`. Passing `auto` lets
+SequoiaRecover choose a compression method based on your network speed to help
+reduce transfer costs.
 To run automated backups every hour:
 ```bash
 sequoiarecover schedule --source /path/to/data --bucket my-bucket --interval 3600 --mode incremental


### PR DESCRIPTION
## Summary
- support `auto` compression option and detect link speed on Linux
- detect network speed from `/sys/class/net` and choose compression accordingly
- document the new `--compression auto` usage

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685a2c95066c8324b2e0288d3ac40660