### PR TITLE
Add manpage generation command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "clap_mangen"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc33c849748320656a90832f54a5eeecaa598e92557fb5dedebc3355746d31e4"
+dependencies = [
+ "clap",
+ "roff",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1606,6 +1616,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roff"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
+
+[[package]]
 name = "rpassword"
 version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1758,6 +1774,7 @@ dependencies = [
  "bzip2",
  "chacha20poly1305",
  "clap",
+ "clap_mangen",
  "flate2",
  "num_cpus",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }
+clap_mangen = "0.2"
 tar = "0.4"
 flate2 = "1.0"
 bzip2 = "0.4"

--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ Check available commands and options:
 sequoiarecover --help
 ```
 
+### Generate a man page
+
+You can create a manual page to ship with precompiled binaries:
+
+```bash
+sequoiarecover manpage > sequoiarecover.1
+```
+
+Install `sequoiarecover.1` under your system's `man1` directory so users can run
+`man sequoiarecover` for full documentation.
+
 ### Linux CLI
 
 You can build and run the command-line application on Linux using Cargo:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 use backblaze_b2_client::client::B2Client;
 use bzip2::write::BzEncoder;
 use bzip2::Compression as BzCompression;
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Parser, Subcommand, ValueEnum, CommandFactory};
+use clap_mangen::Man;
 use chacha20poly1305::{aead::{Aead, KeyInit}, ChaCha20Poly1305, Nonce};
 use rand::rngs::OsRng;
 use pbkdf2::pbkdf2_hmac;
@@ -117,6 +118,8 @@ enum Commands {
     },
     /// Initialize encrypted configuration
     Init,
+    /// Generate the SequoiaRecover man page
+    Manpage,
 }
 
 #[derive(Clone, Copy, ValueEnum, Debug, PartialEq)]
@@ -263,6 +266,13 @@ fn main() {
                     }
                 }
                 Err(e) => eprintln!("{}", e),
+            }
+        }
+        Commands::Manpage => {
+            let cmd = Cli::command();
+            let man = Man::new(cmd);
+            if let Err(e) = man.render(&mut std::io::stdout()) {
+                eprintln!("Failed to generate man page: {}", e);
             }
         }
     }


### PR DESCRIPTION
## Summary
- add `clap_mangen` dependency
- implement a `manpage` subcommand printing a roff man page
- document how to generate the man page

## Testing
- `cargo check`
- `cargo build`
- `cargo run -- manpage > /tmp/man.txt`

------
https://chatgpt.com/codex/tasks/task_e_685a3229ce988324b8d2f95db66a0e12