### PR TITLE
Add remote restore capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,8 +275,10 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1773,6 +1775,7 @@ dependencies = [
  "base64 0.21.7",
  "bzip2",
  "chacha20poly1305",
+ "chrono",
  "clap",
  "clap_mangen",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ sha2 = "0.10"
 rand = "0.8"
 rpassword = "7"
 base64 = "0.21"
+chrono = { version = "0.4", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
 - Automated backup scheduling
 - Easy-to-use command-line interface (CLI) with plans for a GUI
 - Focus on disaster recovery and business continuity
+- View past backup history
+- Inspect backup contents without extracting
+- Restore files from archives
+- Retrieve and restore backups directly from Backblaze
 
 ---
 
@@ -56,6 +60,18 @@ reduce transfer costs.
 To run automated backups every hour:
 ```bash
 sequoiarecover schedule --source /path/to/data --bucket my-bucket --interval 3600 --mode incremental
+```
+Show previous backups stored in Backblaze:
+```bash
+sequoiarecover history --bucket my-bucket
+```
+List the contents of a backup archive from Backblaze without downloading:
+```bash
+sequoiarecover list --backup backup.tar --bucket my-bucket
+```
+Restore a backup directly from Backblaze:
+```bash
+sequoiarecover restore --backup backup.tar --bucket my-bucket --destination /restore/path
 ```
 Check available commands and options:
 ```bash


### PR DESCRIPTION
## Summary
- allow `history`, `list`, and `restore` to operate on Backblaze buckets
- implement helpers to download and list backups from Backblaze
- document how to view and restore cloud backups in the README

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685a3588175883249dc0c8e4a3a6a9ba