### PR TITLE
Improve auto compression logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ sequoiarecover backup --source /path/to/data --cloud backblaze --bucket my-bucke
 The `--mode` flag controls whether a **full** or **incremental** backup is performed.
 Incremental mode only archives files that have changed since the previous backup.
 You can control compression with `--compression`. Passing `auto` lets
-SequoiaRecover choose a compression method based on your network speed to help
-reduce transfer costs.
+SequoiaRecover choose a compression method based on your network speed (measured
+over about 5 seconds) to help reduce transfer costs. Use `--compression-threshold`
+to provide a link speed in Mbps and override the automatic detection when needed.
 To run automated backups every hour:
 ```bash
 sequoiarecover schedule --source /path/to/data --bucket my-bucket --interval 3600 --mode incremental

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,9 @@ enum Commands {
         /// URL of the backup server when using the server cloud option
         #[arg(long)]
         server_url: Option<String>,
+        /// Override detected link speed in Mbps when using auto compression
+        #[arg(long)]
+        compression_threshold: Option<u64>,
     },
     /// Schedule automated backups at a fixed interval (in seconds)
     Schedule {
@@ -92,6 +95,9 @@ enum Commands {
         /// URL of the backup server when using the server cloud option
         #[arg(long)]
         server_url: Option<String>,
+        /// Override detected link speed in Mbps when using auto compression
+        #[arg(long)]
+        compression_threshold: Option<u64>,
         /// Interval in seconds between backups
         #[arg(long, default_value_t = 3600)]
         interval: u64,
@@ -182,9 +188,10 @@ fn main() {
             account_id,
             application_key,
             server_url,
+            compression_threshold,
         } => {
             let actual_compression = if compression == CompressionType::Auto {
-                let c = auto_select_compression();
+                let c = auto_select_compression(compression_threshold);
                 println!("Auto selected compression: {:?}", c);
                 c
             } else {
@@ -234,12 +241,13 @@ fn main() {
             account_id,
             application_key,
             server_url,
+            compression_threshold,
             interval,
             max_runs,
             mode,
         } => {
             let actual_compression = if compression == CompressionType::Auto {
-                let c = auto_select_compression();
+                let c = auto_select_compression(compression_threshold);
                 println!("Auto selected compression: {:?}", c);
                 c
             } else {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,6 @@
-use crate::backup::{restore_backup, run_backup, BackupMode, CompressionType};
+use crate::backup::{
+    auto_select_compression, restore_backup, run_backup, BackupMode, CompressionType,
+};
 use crate::config::{decrypt_config, encrypt_config, Config};
 use crate::remote::{download_from_backblaze_blocking, upload_to_backblaze_blocking};
 use serial_test::serial;
@@ -108,4 +110,11 @@ fn test_download_missing_bucket() -> Result<(), Box<dyn std::error::Error>> {
 
     std::env::remove_var("LOCAL_B2_DIR");
     Ok(())
+}
+
+#[test]
+fn test_auto_select_compression_override() {
+    assert_eq!(auto_select_compression(Some(1500)), CompressionType::None);
+    assert_eq!(auto_select_compression(Some(200)), CompressionType::Gzip);
+    assert_eq!(auto_select_compression(Some(50)), CompressionType::Zstd);
 }


### PR DESCRIPTION
## Summary
- detect link speed over a 5s window
- allow overriding the detected speed via `--compression-threshold`
- test the override logic

## Testing
- `cargo test --quiet`
- `cargo check --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685ab3862aac832489babfe8d01672c3