### PR TITLE
Add progress bar and config to GUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,6 +1092,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3124,6 +3145,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orbclient"
 version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3467,6 +3494,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags 2.9.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3851,6 +3889,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_mangen",
+ "directories",
  "eframe",
  "flate2",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ reqwest = { version = "0.11", features = ["blocking", "json"] }
 bytes = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+directories = "5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ cargo run --bin sequoiarecover-gui
 ```
 
 The GUI currently supports running a full backup with gzip compression.
+While a backup runs a progress bar is displayed. The last used source and output
+paths are saved in a small configuration file under the system's config
+directory.
 
 ### Backblaze Authentication
 

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -39,6 +39,140 @@ pub enum BackupMode {
     Incremental,
 }
 
+fn count_files(
+    root: &Path,
+    mode: BackupMode,
+    previous: &HashMap<String, u64>,
+) -> Result<u64, Box<dyn Error>> {
+    let mut count = 0u64;
+    for entry in WalkDir::new(root) {
+        let entry = entry?;
+        if entry.depth() == 0 && entry.file_type().is_dir() {
+            continue;
+        }
+        if entry.file_type().is_file() {
+            let rel = entry.path().strip_prefix(root)?;
+            let rel_str = rel.to_string_lossy().to_string();
+            let mtime = entry
+                .metadata()?
+                .modified()?
+                .duration_since(UNIX_EPOCH)?
+                .as_secs();
+            let include = match mode {
+                BackupMode::Full => true,
+                BackupMode::Incremental => previous.get(&rel_str).map_or(true, |old| *old < mtime),
+            };
+            if include {
+                count += 1;
+            }
+        }
+    }
+    Ok(count)
+}
+
+pub fn run_backup_with_progress<F>(
+    source: &str,
+    output: &str,
+    compression: CompressionType,
+    mode: BackupMode,
+    mut progress: F,
+) -> Result<(), Box<dyn Error>>
+where
+    F: FnMut(u64, u64),
+{
+    let path = Path::new(source);
+    let meta_path = format!("{}.meta", output);
+    let previous: HashMap<String, u64> = if let Ok(f) = File::open(&meta_path) {
+        serde_json::from_reader(f)?
+    } else {
+        HashMap::new()
+    };
+    let mut current: HashMap<String, u64> = HashMap::new();
+
+    let file = File::create(output)?;
+
+    let actual = if compression == CompressionType::Auto {
+        auto_select_compression(None)
+    } else {
+        compression
+    };
+
+    let total = count_files(path, mode, &previous)?;
+    let mut done = 0u64;
+
+    match actual {
+        CompressionType::Gzip => {
+            let enc = GzEncoder::new(file, GzCompression::default());
+            let mut tar = Builder::new(enc);
+            add_files_progress(
+                &mut tar,
+                path,
+                mode,
+                &previous,
+                &mut current,
+                &mut done,
+                total,
+                &mut progress,
+            )?;
+            let enc = tar.into_inner()?;
+            enc.finish()?;
+        }
+        CompressionType::Bzip2 => {
+            let enc = BzEncoder::new(file, BzCompression::default());
+            let mut tar = Builder::new(enc);
+            add_files_progress(
+                &mut tar,
+                path,
+                mode,
+                &previous,
+                &mut current,
+                &mut done,
+                total,
+                &mut progress,
+            )?;
+            let enc = tar.into_inner()?;
+            enc.finish()?;
+        }
+        CompressionType::Zstd => {
+            let mut enc = ZstdEncoder::new(file, 0)?;
+            enc.multithread(num_cpus::get() as u32)?;
+            let mut tar = Builder::new(enc);
+            add_files_progress(
+                &mut tar,
+                path,
+                mode,
+                &previous,
+                &mut current,
+                &mut done,
+                total,
+                &mut progress,
+            )?;
+            let enc = tar.into_inner()?;
+            enc.finish()?;
+        }
+        CompressionType::None => {
+            let mut tar = Builder::new(file);
+            add_files_progress(
+                &mut tar,
+                path,
+                mode,
+                &previous,
+                &mut current,
+                &mut done,
+                total,
+                &mut progress,
+            )?;
+            tar.finish()?;
+        }
+        CompressionType::Auto => unreachable!(),
+    }
+
+    let meta_file = File::create(&meta_path)?;
+    serde_json::to_writer_pretty(meta_file, &current)?;
+    record_backup(output, mode, actual)?;
+    Ok(())
+}
+
 pub fn run_backup(
     source: &str,
     output: &str,
@@ -66,14 +200,34 @@ pub fn run_backup(
         CompressionType::Gzip => {
             let enc = GzEncoder::new(file, GzCompression::default());
             let mut tar = Builder::new(enc);
-            add_files(&mut tar, path, mode, &previous, &mut current)?;
+            let mut dummy = 0u64;
+            add_files_progress(
+                &mut tar,
+                path,
+                mode,
+                &previous,
+                &mut current,
+                &mut dummy,
+                0,
+                &mut |_d, _t| {},
+            )?;
             let enc = tar.into_inner()?;
             enc.finish()?;
         }
         CompressionType::Bzip2 => {
             let enc = BzEncoder::new(file, BzCompression::default());
             let mut tar = Builder::new(enc);
-            add_files(&mut tar, path, mode, &previous, &mut current)?;
+            let mut dummy = 0u64;
+            add_files_progress(
+                &mut tar,
+                path,
+                mode,
+                &previous,
+                &mut current,
+                &mut dummy,
+                0,
+                &mut |_d, _t| {},
+            )?;
             let enc = tar.into_inner()?;
             enc.finish()?;
         }
@@ -81,13 +235,33 @@ pub fn run_backup(
             let mut enc = ZstdEncoder::new(file, 0)?;
             enc.multithread(num_cpus::get() as u32)?;
             let mut tar = Builder::new(enc);
-            add_files(&mut tar, path, mode, &previous, &mut current)?;
+            let mut dummy = 0u64;
+            add_files_progress(
+                &mut tar,
+                path,
+                mode,
+                &previous,
+                &mut current,
+                &mut dummy,
+                0,
+                &mut |_d, _t| {},
+            )?;
             let enc = tar.into_inner()?;
             enc.finish()?;
         }
         CompressionType::None => {
             let mut tar = Builder::new(file);
-            add_files(&mut tar, path, mode, &previous, &mut current)?;
+            let mut dummy = 0u64;
+            add_files_progress(
+                &mut tar,
+                path,
+                mode,
+                &previous,
+                &mut current,
+                &mut dummy,
+                0,
+                &mut |_d, _t| {},
+            )?;
             tar.finish()?;
         }
         CompressionType::Auto => unreachable!(),
@@ -99,12 +273,15 @@ pub fn run_backup(
     Ok(())
 }
 
-fn add_files<T: std::io::Write>(
+fn add_files_progress<T: std::io::Write>(
     tar: &mut Builder<T>,
     root: &Path,
     mode: BackupMode,
     previous: &HashMap<String, u64>,
     current: &mut HashMap<String, u64>,
+    done: &mut u64,
+    total: u64,
+    progress: &mut dyn FnMut(u64, u64),
 ) -> Result<(), Box<dyn Error>> {
     for entry in WalkDir::new(root) {
         let entry = entry?;
@@ -127,6 +304,8 @@ fn add_files<T: std::io::Write>(
             };
             if include {
                 tar.append_path_with_name(path, rel)?;
+                *done += 1;
+                progress(*done, total);
             }
         }
     }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,11 +1,44 @@
+use directories::ProjectDirs;
 use eframe::egui;
+use sequoiarecover::backup::{run_backup_with_progress, BackupMode, CompressionType};
+use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
-use sequoiarecover::backup::{run_backup, BackupMode, CompressionType};
+
+#[derive(Serialize, Deserialize, Default)]
+struct GuiConfig {
+    source: String,
+    output: String,
+}
 
 struct App {
     source: String,
     output: String,
     status: Arc<Mutex<String>>,
+    progress: Arc<Mutex<f32>>,
+}
+
+fn load_config() -> GuiConfig {
+    if let Some(proj) = ProjectDirs::from("org", "", "SequoiaRecover") {
+        let path = proj.config_dir().join("gui_config.json");
+        if let Ok(f) = std::fs::File::open(path) {
+            serde_json::from_reader(f).unwrap_or_default()
+        } else {
+            GuiConfig::default()
+        }
+    } else {
+        GuiConfig::default()
+    }
+}
+
+fn save_config(cfg: &GuiConfig) {
+    if let Some(proj) = ProjectDirs::from("org", "", "SequoiaRecover") {
+        let dir = proj.config_dir();
+        let _ = std::fs::create_dir_all(dir);
+        let path = dir.join("gui_config.json");
+        if let Ok(f) = std::fs::File::create(path) {
+            let _ = serde_json::to_writer_pretty(f, cfg);
+        }
+    }
 }
 
 impl eframe::App for App {
@@ -24,17 +57,35 @@ impl eframe::App for App {
                 let source = self.source.clone();
                 let output = self.output.clone();
                 let status = self.status.clone();
+                let progress = self.progress.clone();
                 std::thread::spawn(move || {
-                    let res = run_backup(&source, &output, CompressionType::Gzip, BackupMode::Full);
+                    let res = run_backup_with_progress(
+                        &source,
+                        &output,
+                        CompressionType::Gzip,
+                        BackupMode::Full,
+                        |d, t| {
+                            let mut p = progress.lock().unwrap();
+                            if t > 0 {
+                                *p = d as f32 / t as f32;
+                            }
+                        },
+                    );
                     let mut s = status.lock().unwrap();
                     *s = match res {
                         Ok(_) => "Backup complete".to_string(),
                         Err(e) => format!("Error: {}", e),
                     };
                 });
+                save_config(&GuiConfig {
+                    source: self.source.clone(),
+                    output: self.output.clone(),
+                });
             }
             let msg = self.status.lock().unwrap().clone();
             ui.label(msg);
+            let value = *self.progress.lock().unwrap();
+            ui.add(egui::ProgressBar::new(value).show_percentage());
         });
     }
 }
@@ -44,12 +95,13 @@ fn main() -> Result<(), eframe::Error> {
         "SequoiaRecover",
         eframe::NativeOptions::default(),
         Box::new(|_cc| {
+            let cfg = load_config();
             Ok(Box::new(App {
-                source: String::new(),
-                output: String::new(),
+                source: cfg.source,
+                output: cfg.output,
                 status: Arc::new(Mutex::new(String::new())),
+                progress: Arc::new(Mutex::new(0.0)),
             }))
         }),
     )
 }
-


### PR DESCRIPTION
## Summary
- show backup progress in the GUI using `egui::ProgressBar`
- persist GUI paths in a configuration file via `directories`
- implement `run_backup_with_progress` helper for progress reporting
- document the GUI improvements
- remove outdated screenshot

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685ab5b113d8832489c0ca6f4434e6d8