### PR TITLE
Add checksum verification and retention policy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,4 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 [dev-dependencies]
 tempfile = "3"
 serial_test = "2"
+filetime = "0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,12 @@ enum Commands {
         /// URL of the backup server when using the server cloud option
         #[arg(long)]
         server_url: Option<String>,
+        /// Delete backups older than this many days
+        #[arg(long)]
+        retain_days: Option<u64>,
+        /// Delete backups older than this many weeks
+        #[arg(long)]
+        retain_weeks: Option<u64>,
     },
     /// List files inside a backup without extracting
     List {
@@ -305,12 +311,17 @@ fn main() {
             account_id,
             application_key,
             server_url,
+            retain_days,
+            retain_weeks,
         } => {
+            let retention = retain_days
+                .map(|d| Duration::from_secs(d * 24 * 3600))
+                .or_else(|| retain_weeks.map(|w| Duration::from_secs(w * 7 * 24 * 3600)));
             if let Some(b) = bucket {
                 if cloud == "backblaze" {
                     match load_credentials(account_id, application_key) {
                         Ok((id, key)) => {
-                            if let Err(e) = show_remote_history_blocking(&id, &key, &b) {
+                            if let Err(e) = show_remote_history_blocking(&id, &key, &b, retention) {
                                 eprintln!("{}", e);
                             }
                         }


### PR DESCRIPTION
## Summary
- verify SHA256 checksum when uploading to Backblaze or local storage
- allow removing old backups when listing remote history
- support `--retain-days` and `--retain-weeks` CLI options
- test checksum verification and cleanup of expired files

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685ab8e940c08324b60720b05bf3f1dc