### PR TITLE
Add Backblaze integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,19 @@ RUST_LOG=info sequoiarecover backup --source /data --bucket my-bucket
 
 Use `debug` for even more verbose logs.
 
+### Running Backblaze integration tests
+
+Some integration tests interact with Backblaze B2. To enable them set the
+following environment variables before running `cargo test`:
+
+```bash
+export B2_ACCOUNT_ID=your_account_id
+export B2_APPLICATION_KEY=your_application_key
+export B2_BUCKET=your_test_bucket
+```
+
+If these variables are not defined the Backblaze tests are skipped.
+
 ## Release Process
 
 SequoiaRecover uses GitHub Actions to build binaries for Windows, macOS and Linux whenever a new version tag is pushed. The workflow is defined in `.github/workflows/release.yml` and can also be triggered manually from the GitHub web UI.

--- a/tests/backblaze.rs
+++ b/tests/backblaze.rs
@@ -1,0 +1,44 @@
+use sequoiarecover::remote::{download_from_backblaze_blocking, upload_to_backblaze_blocking};
+use serial_test::serial;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+#[serial]
+fn backblaze_upload_download() -> Result<(), Box<dyn std::error::Error>> {
+    let id = match std::env::var("B2_ACCOUNT_ID") {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("Skipping Backblaze test: B2_ACCOUNT_ID not set");
+            return Ok(());
+        }
+    };
+    let key = match std::env::var("B2_APPLICATION_KEY") {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("Skipping Backblaze test: B2_APPLICATION_KEY not set");
+            return Ok(());
+        }
+    };
+    let bucket = match std::env::var("B2_BUCKET") {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("Skipping Backblaze test: B2_BUCKET not set");
+            return Ok(());
+        }
+    };
+
+    let dir = tempdir()?;
+    let src_file = dir.path().join("data.txt");
+    fs::write(&src_file, b"b2test")?;
+
+    upload_to_backblaze_blocking(&id, &key, &bucket, src_file.to_str().unwrap())?;
+
+    let dest_file = dir.path().join("out.txt");
+    download_from_backblaze_blocking(&id, &key, &bucket, "data.txt", &dest_file)?;
+
+    let content = fs::read_to_string(dest_file)?;
+    assert_eq!(content, "b2test");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add an integration test that uploads and downloads a file to Backblaze
- document required B2_* environment variables for running the test

## Testing
- `cargo test -- --test-threads=1` *(fails: lock file version 4 requires `-Znext-lockfile-bump`)*

------
https://chatgpt.com/codex/tasks/task_e_685ab8f889c08324a069f2088e2b0291