### PR TITLE
Refine GUI settings and history display

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ A minimal graphical interface is available as a separate binary:
 cargo run --bin sequoiarecover-gui
 ```
 
-The GUI currently supports running a full backup with gzip compression.
-While a backup runs a progress bar is displayed. The last used source and output
-paths are saved in a small configuration file under the system's config
-directory.
+The GUI provides a multi-tab interface for running backups, restoring archives,
+browsing history and initializing credentials. Compression and backup mode
+selections are persisted between sessions alongside the most recent paths.
+While a backup runs a progress bar is displayed.
 
 ### Backblaze Authentication
 

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -33,10 +33,22 @@ pub enum CompressionType {
     Auto,
 }
 
-#[derive(Clone, Copy, ValueEnum, Debug, Serialize, Deserialize)]
+impl Default for CompressionType {
+    fn default() -> Self {
+        CompressionType::Gzip
+    }
+}
+
+#[derive(Clone, Copy, ValueEnum, Debug, Serialize, Deserialize, PartialEq)]
 pub enum BackupMode {
     Full,
     Incremental,
+}
+
+impl Default for BackupMode {
+    fn default() -> Self {
+        BackupMode::Full
+    }
 }
 
 fn count_files(

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,20 +1,52 @@
 use directories::ProjectDirs;
-use eframe::egui;
-use sequoiarecover::backup::{run_backup_with_progress, BackupMode, CompressionType};
+use eframe::egui::{self, ComboBox, TextEdit};
+use sequoiarecover::backup::{
+    restore_backup, run_backup_with_progress, BackupMode, CompressionType,
+};
+use sequoiarecover::config::{
+    config_file_path, encrypt_config, history_file_path, Config, HistoryEntry,
+};
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
 
 #[derive(Serialize, Deserialize, Default)]
 struct GuiConfig {
+    #[serde(default)]
     source: String,
+    #[serde(default)]
     output: String,
+    #[serde(default)]
+    restore_path: String,
+    #[serde(default)]
+    restore_dest: String,
+    #[serde(default)]
+    compression: CompressionType,
+    #[serde(default)]
+    mode: BackupMode,
+}
+
+enum Tab {
+    Backup,
+    Restore,
+    History,
+    Settings,
 }
 
 struct App {
+    tab: Tab,
     source: String,
     output: String,
+    compression: CompressionType,
+    mode: BackupMode,
+    restore_path: String,
+    restore_dest: String,
+    history: Vec<HistoryEntry>,
     status: Arc<Mutex<String>>,
     progress: Arc<Mutex<f32>>,
+    account_id: String,
+    application_key: String,
+    password: String,
+    confirm: String,
 }
 
 fn load_config() -> GuiConfig {
@@ -41,51 +73,229 @@ fn save_config(cfg: &GuiConfig) {
     }
 }
 
+fn load_history() -> Vec<HistoryEntry> {
+    if let Ok(path) = history_file_path() {
+        if let Ok(f) = std::fs::File::open(path) {
+            serde_json::from_reader(f).unwrap_or_default()
+        } else {
+            Vec::new()
+        }
+    } else {
+        Vec::new()
+    }
+}
+
 impl eframe::App for App {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        egui::CentralPanel::default().show(ctx, |ui| {
-            ui.heading("SequoiaRecover GUI");
+        egui::TopBottomPanel::top("tabs").show(ctx, |ui| {
             ui.horizontal(|ui| {
-                ui.label("Source:");
-                ui.text_edit_singleline(&mut self.source);
+                if ui
+                    .selectable_label(matches!(self.tab, Tab::Backup), "Backup")
+                    .clicked()
+                {
+                    self.tab = Tab::Backup;
+                }
+                if ui
+                    .selectable_label(matches!(self.tab, Tab::Restore), "Restore")
+                    .clicked()
+                {
+                    self.tab = Tab::Restore;
+                }
+                if ui
+                    .selectable_label(matches!(self.tab, Tab::History), "History")
+                    .clicked()
+                {
+                    self.tab = Tab::History;
+                }
+                if ui
+                    .selectable_label(matches!(self.tab, Tab::Settings), "Settings")
+                    .clicked()
+                {
+                    self.tab = Tab::Settings;
+                }
             });
-            ui.horizontal(|ui| {
-                ui.label("Output:");
-                ui.text_edit_singleline(&mut self.output);
-            });
-            if ui.button("Run Backup").clicked() {
-                let source = self.source.clone();
-                let output = self.output.clone();
-                let status = self.status.clone();
-                let progress = self.progress.clone();
-                std::thread::spawn(move || {
-                    let res = run_backup_with_progress(
-                        &source,
-                        &output,
-                        CompressionType::Gzip,
-                        BackupMode::Full,
-                        |d, t| {
-                            let mut p = progress.lock().unwrap();
-                            if t > 0 {
-                                *p = d as f32 / t as f32;
-                            }
-                        },
-                    );
-                    let mut s = status.lock().unwrap();
-                    *s = match res {
-                        Ok(_) => "Backup complete".to_string(),
-                        Err(e) => format!("Error: {}", e),
-                    };
+        });
+
+        egui::CentralPanel::default().show(ctx, |ui| match self.tab {
+            Tab::Backup => {
+                ui.heading("Run Backup");
+                ui.horizontal(|ui| {
+                    ui.label("Source:");
+                    ui.text_edit_singleline(&mut self.source);
                 });
-                save_config(&GuiConfig {
-                    source: self.source.clone(),
-                    output: self.output.clone(),
+                ui.horizontal(|ui| {
+                    ui.label("Output:");
+                    ui.text_edit_singleline(&mut self.output);
                 });
+                ComboBox::from_label("Compression")
+                    .selected_text(format!("{:?}", self.compression))
+                    .show_ui(ui, |ui| {
+                        ui.selectable_value(&mut self.compression, CompressionType::None, "None");
+                        ui.selectable_value(&mut self.compression, CompressionType::Gzip, "Gzip");
+                        ui.selectable_value(&mut self.compression, CompressionType::Bzip2, "Bzip2");
+                        ui.selectable_value(&mut self.compression, CompressionType::Zstd, "Zstd");
+                    });
+                ComboBox::from_label("Mode")
+                    .selected_text(format!("{:?}", self.mode))
+                    .show_ui(ui, |ui| {
+                        ui.selectable_value(&mut self.mode, BackupMode::Full, "Full");
+                        ui.selectable_value(&mut self.mode, BackupMode::Incremental, "Incremental");
+                    });
+                if ui.button("Run Backup").clicked() {
+                    let source = self.source.clone();
+                    let output = self.output.clone();
+                    let compression = self.compression;
+                    let mode = self.mode;
+                    let status = self.status.clone();
+                    let progress = self.progress.clone();
+                    std::thread::spawn(move || {
+                        let res = run_backup_with_progress(
+                            &source,
+                            &output,
+                            compression,
+                            mode,
+                            |d, t| {
+                                let mut p = progress.lock().unwrap();
+                                if t > 0 {
+                                    *p = d as f32 / t as f32;
+                                }
+                            },
+                        );
+                        let mut s = status.lock().unwrap();
+                        *s = match res {
+                            Ok(_) => "Backup complete".to_string(),
+                            Err(e) => format!("Error: {}", e),
+                        };
+                    });
+                    save_config(&GuiConfig {
+                        source: self.source.clone(),
+                        output: self.output.clone(),
+                        restore_path: self.restore_path.clone(),
+                        restore_dest: self.restore_dest.clone(),
+                        compression: self.compression,
+                        mode: self.mode,
+                    });
+                    self.history = load_history();
+                }
+                let msg = self.status.lock().unwrap().clone();
+                ui.label(msg);
+                let value = *self.progress.lock().unwrap();
+                ui.add(egui::ProgressBar::new(value).show_percentage());
             }
-            let msg = self.status.lock().unwrap().clone();
-            ui.label(msg);
-            let value = *self.progress.lock().unwrap();
-            ui.add(egui::ProgressBar::new(value).show_percentage());
+            Tab::Restore => {
+                ui.heading("Restore Backup");
+                ui.horizontal(|ui| {
+                    ui.label("Backup file:");
+                    ui.text_edit_singleline(&mut self.restore_path);
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Destination:");
+                    ui.text_edit_singleline(&mut self.restore_dest);
+                });
+                if ui.button("Restore").clicked() {
+                    let src = self.restore_path.clone();
+                    let dst = self.restore_dest.clone();
+                    let status = self.status.clone();
+                    std::thread::spawn(move || {
+                        let res = restore_backup(&src, &dst, None);
+                        let mut s = status.lock().unwrap();
+                        *s = match res {
+                            Ok(_) => "Restore complete".to_string(),
+                            Err(e) => format!("Error: {}", e),
+                        };
+                    });
+                    save_config(&GuiConfig {
+                        source: self.source.clone(),
+                        output: self.output.clone(),
+                        restore_path: self.restore_path.clone(),
+                        restore_dest: self.restore_dest.clone(),
+                        compression: self.compression,
+                        mode: self.mode,
+                    });
+                }
+                let msg = self.status.lock().unwrap().clone();
+                ui.label(msg);
+            }
+            Tab::History => {
+                ui.heading("Backup History");
+                if self.history.is_empty() {
+                    ui.label("No history available");
+                } else {
+                    egui::ScrollArea::vertical().show(ui, |ui| {
+                        for entry in &self.history {
+                            let dt = chrono::DateTime::<chrono::Utc>::from_timestamp(
+                                entry.timestamp as i64,
+                                0,
+                            )
+                            .unwrap()
+                            .with_timezone(&chrono::Local);
+                            ui.horizontal(|ui| {
+                                ui.label(dt.format("%Y-%m-%d %H:%M:%S").to_string());
+                                ui.label(format!("{:?}", entry.mode));
+                                ui.label(&entry.backup);
+                            });
+                        }
+                    });
+                }
+            }
+            Tab::Settings => {
+                ui.heading("Initialize Config");
+                ui.horizontal(|ui| {
+                    ui.label("Account ID:");
+                    ui.text_edit_singleline(&mut self.account_id);
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Application Key:");
+                    ui.text_edit_singleline(&mut self.application_key);
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Password:");
+                    ui.add(TextEdit::singleline(&mut self.password).password(true));
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Confirm:");
+                    ui.add(TextEdit::singleline(&mut self.confirm).password(true));
+                });
+                if ui.button("Init").clicked() {
+                    if self.password != self.confirm {
+                        let mut s = self.status.lock().unwrap();
+                        *s = "Passwords do not match".into();
+                    } else if let Ok(path) = config_file_path() {
+                        let cfg = Config {
+                            account_id: self.account_id.clone(),
+                            application_key: self.application_key.clone(),
+                        };
+                        match encrypt_config(&cfg, &self.password) {
+                            Ok(enc) => {
+                                if let Some(p) = path.parent() {
+                                    let _ = std::fs::create_dir_all(p);
+                                }
+                                if let Ok(f) = std::fs::File::create(&path) {
+                                    if serde_json::to_writer_pretty(f, &enc).is_ok() {
+                                        let mut s = self.status.lock().unwrap();
+                                        *s = format!("Config written to {:?}", path);
+                                    } else {
+                                        let mut s = self.status.lock().unwrap();
+                                        *s = "Failed to write config".into();
+                                    }
+                                } else {
+                                    let mut s = self.status.lock().unwrap();
+                                    *s = "Could not create config file".into();
+                                }
+                            }
+                            Err(e) => {
+                                let mut s = self.status.lock().unwrap();
+                                *s = format!("Failed to encrypt config: {}", e);
+                            }
+                        }
+                    } else {
+                        let mut s = self.status.lock().unwrap();
+                        *s = "Could not determine config path".into();
+                    }
+                }
+                let msg = self.status.lock().unwrap().clone();
+                ui.label(msg);
+            }
         });
     }
 }
@@ -97,10 +307,20 @@ fn main() -> Result<(), eframe::Error> {
         Box::new(|_cc| {
             let cfg = load_config();
             Ok(Box::new(App {
+                tab: Tab::Backup,
                 source: cfg.source,
                 output: cfg.output,
+                compression: cfg.compression,
+                mode: cfg.mode,
+                restore_path: cfg.restore_path,
+                restore_dest: cfg.restore_dest,
+                history: load_history(),
                 status: Arc::new(Mutex::new(String::new())),
                 progress: Arc::new(Mutex::new(0.0)),
+                account_id: String::new(),
+                application_key: String::new(),
+                password: String::new(),
+                confirm: String::new(),
             }))
         }),
     )


### PR DESCRIPTION
## Summary
- derive `Default` for `GuiConfig`
- update backup history timestamps using chrono `DateTime`
- describe new GUI capabilities in README

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685b6683ba28832488f0a0ffc09e3869