### PR TITLE
Add TLS and auth token options to server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4934,7 +4934,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -5152,6 +5152,20 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
@@ -5171,7 +5185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "schannel",
  "security-framework 2.11.1",
 ]
@@ -5198,6 +5212,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5213,6 +5236,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -6113,6 +6147,17 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
@@ -6518,11 +6563,13 @@ dependencies = [
  "multer",
  "percent-encoding",
  "pin-project",
+ "rustls-pemfile 2.2.0",
  "scoped-tls",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-rustls 0.25.0",
  "tokio-tungstenite",
  "tokio-util",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ base64 = "0.21"
 chrono = { version = "0.4", features = ["serde"] }
 sysinfo = "0.35"
 eframe = "0.31"
-warp = "0.3"
+warp = { version = "0.3", features = ["tls"] }
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 bytes = "1"
 tracing = "0.1"

--- a/docs/server.md
+++ b/docs/server.md
@@ -7,11 +7,14 @@ SequoiaRecover includes an optional HTTP server for storing backups on your own 
 Use the `serve` subcommand to start the server:
 
 ```bash
-sequoiarecover serve --address 0.0.0.0:3030 --dir /path/to/storage
+sequoiarecover serve --address 0.0.0.0:3030 --dir /path/to/storage \
+    --cert cert.pem --key key.pem --auth-token secret
 ```
 
 - `--address` sets the IP and port to listen on.
 - `--dir` is the directory where uploaded backups are saved.
+- `--cert` and `--key` enable TLS using the provided certificate and key.
+- `--auth-token` requires clients to send this value in the `Authorization` header.
 
 ## Uploading to the server
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,6 +190,15 @@ enum Commands {
         /// Directory to store uploaded backups
         #[arg(long, default_value = "storage")]
         dir: String,
+        /// Path to TLS certificate
+        #[arg(long)]
+        cert: Option<String>,
+        /// Path to TLS private key
+        #[arg(long)]
+        key: Option<String>,
+        /// Authorization token required on requests
+        #[arg(long)]
+        auth_token: Option<String>,
     },
     /// Initialize encrypted configuration
     Init {
@@ -558,7 +567,13 @@ fn main() {
                 eprintln!("{}", e);
             }
         }
-        Commands::Serve { address, dir } => {
+        Commands::Serve {
+            address,
+            dir,
+            cert,
+            key,
+            auth_token,
+        } => {
             let addr: std::net::SocketAddr = match address.parse() {
                 Ok(a) => a,
                 Err(e) => {
@@ -567,7 +582,13 @@ fn main() {
                 }
             };
             let rt = tokio::runtime::Runtime::new().expect("runtime");
-            if let Err(e) = rt.block_on(run_server(addr, dir.into())) {
+            if let Err(e) = rt.block_on(run_server(
+                addr,
+                dir.into(),
+                cert.map(Into::into),
+                key.map(Into::into),
+                auth_token,
+            )) {
                 eprintln!("{}", e);
             }
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -164,7 +164,7 @@ fn test_auto_select_compression_override() {
 #[tokio::test]
 async fn test_server_rejects_malicious_paths() {
     let dir = tempdir().unwrap();
-    let filter = make_routes(dir.path().into()).recover(handle_rejection);
+    let filter = make_routes(dir.path().into(), None).recover(handle_rejection);
 
     let resp = warp_request()
         .method("POST")
@@ -202,7 +202,7 @@ async fn test_server_stream_upload() {
     use tokio::io::AsyncReadExt;
 
     let dir = tempdir().unwrap();
-    let filter = make_routes(dir.path().into()).recover(handle_rejection);
+    let filter = make_routes(dir.path().into(), None).recover(handle_rejection);
 
     let data = vec![0u8; 5 * 1024 * 1024];
     let resp = warp_request()
@@ -228,7 +228,7 @@ async fn test_upload_to_server_blocking_large_file() -> Result<(), Box<dyn std::
 
     let dir = tempdir()?;
     let storage_dir = dir.path().join("storage");
-    let filter = make_routes(storage_dir.clone()).recover(handle_rejection);
+    let filter = make_routes(storage_dir.clone(), None).recover(handle_rejection);
     let (addr, server) = warp::serve(filter).bind_ephemeral(([127, 0, 0, 1], 0));
     let srv_handle = task::spawn(server);
 


### PR DESCRIPTION
## Summary
- support rustls TLS for the local server
- add optional token-based authentication
- expose --cert, --key and --auth-token arguments in `serve`
- document new server options

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685e08bca05c8324b10954b8ab664127