### PR TITLE
Add basic GUI with eframe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,8 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
           override: true
-      - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+      - name: Build CLI and GUI
+        run: cargo build --release --target ${{ matrix.target }} --bins
       - name: Sign binaries (Windows)
         if: matrix.os == 'windows-latest' && env.WINDOWS_CERTIFICATE && env.WINDOWS_CERT_PASSWORD
         shell: pwsh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,12 +1885,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
-
-[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2832,30 +2826,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "headers"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "headers-core",
- "http 0.2.12",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
-dependencies = [
- "http 0.2.12",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3670,16 +3640,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3704,24 +3664,6 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "multer"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http 0.2.12",
- "httparse",
- "log",
- "memchr",
- "mime",
- "spin",
- "version_check",
 ]
 
 [[package]]
@@ -4934,7 +4876,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -5152,20 +5094,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
@@ -5185,7 +5113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "schannel",
  "security-framework 2.11.1",
 ]
@@ -5212,15 +5140,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5236,17 +5155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
  "untrusted",
 ]
 
@@ -5424,7 +5332,6 @@ dependencies = [
  "azure_storage_blobs",
  "backblaze-b2-client",
  "base64 0.21.7",
- "bytes",
  "bzip2",
  "chacha20poly1305",
  "chrono",
@@ -5438,9 +5345,7 @@ dependencies = [
  "keyring",
  "num_cpus",
  "pbkdf2",
- "percent-encoding",
  "rand 0.8.5",
- "reqwest 0.11.27",
  "rfd",
  "rpassword",
  "serde",
@@ -5455,7 +5360,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "walkdir",
- "warp",
  "zstd",
 ]
 
@@ -5734,12 +5638,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spirv"
@@ -6147,35 +6045,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls 0.23.28",
  "tokio",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite",
 ]
 
 [[package]]
@@ -6270,7 +6145,6 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -6339,25 +6213,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
-name = "tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.3.1",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
- "thiserror 1.0.69",
- "url",
- "utf-8",
-]
-
-[[package]]
 name = "type-map"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6402,12 +6257,6 @@ dependencies = [
  "tempfile",
  "winapi",
 ]
-
-[[package]]
-name = "unicase"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
@@ -6466,12 +6315,6 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -6543,37 +6386,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
-]
-
-[[package]]
-name = "warp"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "headers",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "mime",
- "mime_guess",
- "multer",
- "percent-encoding",
- "pin-project",
- "rustls-pemfile 2.2.0",
- "scoped-tls",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-rustls 0.25.0",
- "tokio-tungstenite",
- "tokio-util",
- "tower-service",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ path = "src/lib.rs"
 name = "sequoiarecover"
 path = "src/main.rs"
 
+[[bin]]
+name = "sequoiarecover-gui"
+path = "ui/main.rs"
+
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }
 clap_mangen = "0.2"

--- a/ui/api.rs
+++ b/ui/api.rs
@@ -1,0 +1,44 @@
+use std::error::Error;
+use std::thread;
+use std::time::Duration;
+
+use sequoiarecover::backup::{run_backup, BackupMode, CompressionType};
+use sequoiarecover::config::{history_file_path, HistoryEntry};
+
+#[derive(Default, Clone)]
+pub struct BackupConfig {
+    pub source: String,
+    pub output: String,
+    pub compression: CompressionType,
+    pub mode: BackupMode,
+}
+
+pub fn perform_backup(cfg: &BackupConfig) -> Result<(), String> {
+    run_backup(&cfg.source, &cfg.output, cfg.compression, cfg.mode).map_err(|e| e.to_string())
+}
+
+pub fn schedule_backups(cfg: BackupConfig, interval: u64, max_runs: u64) {
+    thread::spawn(move || {
+        let mut runs = 0u64;
+        loop {
+            if max_runs > 0 && runs >= max_runs {
+                break;
+            }
+            if let Err(e) = perform_backup(&cfg) {
+                eprintln!("Scheduled backup failed: {}", e);
+            }
+            runs += 1;
+            thread::sleep(Duration::from_secs(interval));
+        }
+    });
+}
+
+pub fn load_history() -> Result<Vec<HistoryEntry>, Box<dyn Error>> {
+    let path = history_file_path()?;
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let f = std::fs::File::open(path)?;
+    let history: Vec<HistoryEntry> = serde_json::from_reader(f)?;
+    Ok(history)
+}

--- a/ui/main.rs
+++ b/ui/main.rs
@@ -1,0 +1,177 @@
+use chrono::TimeZone;
+use eframe::egui::{self, CentralPanel, ComboBox, TextEdit, TopBottomPanel};
+use sequoiarecover::backup::{BackupMode, CompressionType};
+
+mod api;
+use api::{load_history, perform_backup, schedule_backups, BackupConfig};
+
+#[derive(PartialEq)]
+enum View {
+    Backup,
+    Schedule,
+    History,
+}
+
+struct AppState {
+    view: View,
+    backup_cfg: BackupConfig,
+    interval: u64,
+    max_runs: u64,
+    history: Vec<sequoiarecover::config::HistoryEntry>,
+    status: String,
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self {
+            view: View::Backup,
+            backup_cfg: BackupConfig::default(),
+            interval: 3600,
+            max_runs: 0,
+            history: Vec::new(),
+            status: String::new(),
+        }
+    }
+}
+
+impl eframe::App for AppState {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        TopBottomPanel::top("top").show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                if ui.button("Backup").clicked() {
+                    self.view = View::Backup;
+                }
+                if ui.button("Schedule").clicked() {
+                    self.view = View::Schedule;
+                }
+                if ui.button("History").clicked() {
+                    self.view = View::History;
+                    if let Ok(hist) = load_history() {
+                        self.history = hist;
+                    }
+                }
+            });
+        });
+        CentralPanel::default().show(ctx, |ui| match self.view {
+            View::Backup => self.show_backup(ui),
+            View::Schedule => self.show_schedule(ui),
+            View::History => self.show_history(ui),
+        });
+    }
+}
+
+impl AppState {
+    fn show_backup(&mut self, ui: &mut egui::Ui) {
+        ui.vertical(|ui| {
+            ui.horizontal(|ui| {
+                ui.label("Source:");
+                ui.add(TextEdit::singleline(&mut self.backup_cfg.source).desired_width(200.0));
+            });
+            ui.horizontal(|ui| {
+                ui.label("Output:");
+                ui.add(TextEdit::singleline(&mut self.backup_cfg.output).desired_width(200.0));
+            });
+            ui.horizontal(|ui| {
+                ui.label("Compression:");
+                ComboBox::from_id_source("compression")
+                    .selected_text(format!("{:?}", self.backup_cfg.compression))
+                    .show_ui(ui, |ui| {
+                        ui.selectable_value(
+                            &mut self.backup_cfg.compression,
+                            CompressionType::None,
+                            "None",
+                        );
+                        ui.selectable_value(
+                            &mut self.backup_cfg.compression,
+                            CompressionType::Gzip,
+                            "Gzip",
+                        );
+                        ui.selectable_value(
+                            &mut self.backup_cfg.compression,
+                            CompressionType::Bzip2,
+                            "Bzip2",
+                        );
+                        ui.selectable_value(
+                            &mut self.backup_cfg.compression,
+                            CompressionType::Zstd,
+                            "Zstd",
+                        );
+                    });
+            });
+            ui.horizontal(|ui| {
+                ui.label("Mode:");
+                ComboBox::from_id_source("mode")
+                    .selected_text(format!("{:?}", self.backup_cfg.mode))
+                    .show_ui(ui, |ui| {
+                        ui.selectable_value(&mut self.backup_cfg.mode, BackupMode::Full, "Full");
+                        ui.selectable_value(
+                            &mut self.backup_cfg.mode,
+                            BackupMode::Incremental,
+                            "Incremental",
+                        );
+                    });
+            });
+            if ui.button("Run Backup").clicked() {
+                match perform_backup(&self.backup_cfg) {
+                    Ok(_) => self.status = "Backup completed".into(),
+                    Err(e) => self.status = e,
+                }
+            }
+            ui.label(&self.status);
+        });
+    }
+
+    fn show_schedule(&mut self, ui: &mut egui::Ui) {
+        ui.vertical(|ui| {
+            ui.horizontal(|ui| {
+                ui.label("Interval (s):");
+                let mut int_str = self.interval.to_string();
+                if ui.text_edit_singleline(&mut int_str).lost_focus() {
+                    if let Ok(v) = int_str.parse() {
+                        self.interval = v;
+                    }
+                }
+            });
+            ui.horizontal(|ui| {
+                ui.label("Max runs (0=infinite):");
+                let mut max_str = self.max_runs.to_string();
+                if ui.text_edit_singleline(&mut max_str).lost_focus() {
+                    if let Ok(v) = max_str.parse() {
+                        self.max_runs = v;
+                    }
+                }
+            });
+            if ui.button("Start Schedule").clicked() {
+                schedule_backups(self.backup_cfg.clone(), self.interval, self.max_runs);
+                self.status = "Schedule started".into();
+            }
+            ui.label(&self.status);
+        });
+    }
+
+    fn show_history(&mut self, ui: &mut egui::Ui) {
+        ui.vertical(|ui| {
+            for entry in &self.history {
+                ui.horizontal(|ui| {
+                    let naive =
+                        chrono::NaiveDateTime::from_timestamp_opt(entry.timestamp, 0).unwrap();
+                    let dt: chrono::DateTime<chrono::Local> =
+                        chrono::Local.from_local_datetime(&naive).unwrap();
+                    ui.label(dt.format("%Y-%m-%d %H:%M:%S").to_string());
+                    ui.label(format!("{:?}", entry.mode));
+                    ui.label(&entry.backup);
+                });
+            }
+        });
+    }
+}
+
+fn main() {
+    let options = eframe::NativeOptions::default();
+    eframe::run_native(
+        "SequoiaRecover GUI",
+        options,
+        Box::new(|_cc| Ok(Box::new(AppState::default()))),
+    )
+    .unwrap();
+}


### PR DESCRIPTION
## Summary
- add GUI source under `ui/` using `eframe`
- wire up backup scheduling and history in the GUI
- expose simple API helpers
- build GUI in release workflow

## Testing
- `cargo check`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685e1d59f3408324a6c202fc66fb3f00