### PR TITLE
Enable dynamic storage providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,21 @@ AWS and Azure credentials are read from the environment. Set `AWS_ACCESS_KEY_ID`
 
 ### Plugin-based Storage Providers
 
-Custom providers can be defined in `~/.sequoiarecover/providers.json`. Each entry specifies a name, a provider type such as `backblaze`, `aws` or `azure`, and any necessary credentials. The CLI loads this file on startup to register the providers.
+Custom providers can be defined in `~/.sequoiarecover/providers.json`. Each entry
+specifies a `name`, a provider `type` such as `backblaze`, `aws` or `azure`, and
+any required credentials. The CLI loads this file along with the optional
+`SEQUOIA_PROVIDERS` environment variable (containing the same JSON format) to
+register providers at runtime.
+
+Example environment value:
+
+```bash
+export SEQUOIA_PROVIDERS='{"providers":[{"name":"myb2","type":"backblaze","credentials":{"account_id":"id","application_key":"key"}}]}'
+```
+
+Providers are Rust structs that implement the `StorageProvider` trait in the
+`sequoiarecover-core` crate. Implement the trait for a new backend and register
+it using `register_provider` so the CLI and server can use it.
 
 ### Management Server
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -192,6 +192,8 @@ async fn list_alerts(data: web::Data<AppState>, req: HttpRequest) -> impl Respon
 async fn main() -> std::io::Result<()> {
     let mut rng = rand::thread_rng();
     let secret: [u8; 32] = rng.gen();
+    let _ = sequoiarecover::remote::load_providers_from_config();
+    let _ = sequoiarecover::remote::load_providers_from_env();
     let data = web::Data::new(AppState { users: Mutex::new(HashMap::new()), audit: Mutex::new(Vec::new()), alerts: Mutex::new(Vec::new()), jwt_secret: secret.to_vec() });
     HttpServer::new(move || {
         App::new()


### PR DESCRIPTION
## Summary
- add `load_providers_from_env` to register providers via environment variables
- load providers from config and environment in CLI and server
- simplify CLI to use provider registry only
- document provider registry with examples

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_686432abfe8c83249325e528f90ce6ae